### PR TITLE
[940] Migrate EDI module to Odoo11 + some fixes

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,1 +1,1 @@
-import models
+from . import models

--- a/__manifest__.py
+++ b/__manifest__.py
@@ -32,7 +32,7 @@ Key Features
              'data/edi_document_data.xml',
              'data/edi_gateway_local_data.xml',
              'data/edi_gateway_mail_data.xml',
-             'data/edi_gateway_xmlrpc_data.xml',
+             #'data/edi_gateway_xmlrpc_data.xml',
              'views/edi_menu_views.xml',
              'views/edi_document_views.xml',
              'views/edi_document_type_views.xml',

--- a/__manifest__.py
+++ b/__manifest__.py
@@ -19,10 +19,10 @@ Key Features
 * Send and receive documents to/from remote EDI servers
 * Schedule polling of remote EDI servers
 * Process EDI documents via XML-RPC interface
-* Handle errors via Odoo issue tracker
+* Handle errors via Odoo project manager
     """,
     'version': '0.1',
-    'depends': ['project_issue', 'document'],
+    'depends': ['project', 'document'],
     'external_dependencies': {'python': ['paramiko']},
     'author': 'Michael Brown <mbrown@fensystems.co.uk>',
     'category': 'Extra Tools',

--- a/data/project_issue_data.xml
+++ b/data/project_issue_data.xml
@@ -19,16 +19,9 @@
     <!-- Create "EDI" project -->
     <record id="project_default" model="project.project">
       <field name="name">EDI</field>
-      <field name="use_issues" eval="True"/>
       <field name="use_edi_fields" eval="True"/>
       <field name="type_ids" eval="[(6,0,[ref('task_type_new'),
 					  ref('task_type_closed')])]"/>
-    </record>
-    <!-- Update project to disable use of tasks.  For some convoluted
-	 reason, this does not work at the point of project creation.
-    -->
-    <record id="project_default" model="project.project">
-      <field name="use_tasks" eval="False"/>
     </record>
 
   </data>

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -5,6 +5,6 @@ from . import edi_gateway
 from . import edi_connection_local
 from . import edi_connection_mail
 from . import edi_connection_sftp
-from . import edi_connection_xmlrpc
+#from . import edi_connection_xmlrpc
 from . import edi_record
 from . import edi_transfer

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,10 +1,10 @@
-import edi_attachment_audit
-import edi_issues
-import edi_document
-import edi_gateway
-import edi_connection_local
-import edi_connection_mail
-import edi_connection_sftp
-import edi_connection_xmlrpc
-import edi_record
-import edi_transfer
+from . import edi_attachment_audit
+from . import edi_issues
+from . import edi_document
+from . import edi_gateway
+from . import edi_connection_local
+from . import edi_connection_mail
+from . import edi_connection_sftp
+from . import edi_connection_xmlrpc
+from . import edi_record
+from . import edi_transfer

--- a/models/edi_connection_local.py
+++ b/models/edi_connection_local.py
@@ -51,6 +51,7 @@ class EdiConnectionLocal(models.AbstractModel):
             filepath = os.path.join(path.path, filename)
             stat = os.stat(filepath)
 
+
             # Skip files outside the age window
             if datetime.fromtimestamp(stat.st_mtime) < min_date:
                 continue
@@ -71,7 +72,7 @@ class EdiConnectionLocal(models.AbstractModel):
             attachment = Attachment.create({
                 'name': filename,
                 'datas_fname': filename,
-                'datas': base64.b64encode(str(data)),
+                'datas': base64.b64encode(data),
                 'res_model': 'edi.document',
                 'res_field': 'input_ids',
                 })

--- a/models/edi_connection_local.py
+++ b/models/edi_connection_local.py
@@ -51,7 +51,6 @@ class EdiConnectionLocal(models.AbstractModel):
             filepath = os.path.join(path.path, filename)
             stat = os.stat(filepath)
 
-
             # Skip files outside the age window
             if datetime.fromtimestamp(stat.st_mtime) < min_date:
                 continue

--- a/models/edi_connection_sftp.py
+++ b/models/edi_connection_sftp.py
@@ -1,5 +1,5 @@
 from odoo import api, fields, models
-from odoo.exceptions import UserError
+from odoo.exceptions import ValidationError
 from odoo.tools.translate import _
 from datetime import datetime, timedelta
 import os.path
@@ -86,7 +86,7 @@ class EdiConnectionSFTP(models.AbstractModel):
             attachment = Attachment.create({
                 'name': dirent.filename,
                 'datas_fname': dirent.filename,
-                'datas': base64.b64encode(str(data)),
+                'datas': base64.b64encode(data),
                 'res_model': 'edi.document',
                 'res_field': 'input_ids',
                 })

--- a/models/edi_gateway.py
+++ b/models/edi_gateway.py
@@ -204,7 +204,7 @@ class EdiGateway(models.Model):
                 line = base64.b64decode(gw.ssh_host_key)
                 entry = paramiko.hostkeys.HostKeyEntry.from_line(line.decode())
                 digest = entry.key.get_fingerprint()
-                gw.ssh_host_fingerprint = (':'.join(x.encode('hex')
+                gw.ssh_host_fingerprint = (':'.join(hex(x)[2:]
                                                     for x in digest))
             else:
                 gw.ssh_host_fingerprint = None

--- a/models/edi_gateway.py
+++ b/models/edi_gateway.py
@@ -144,7 +144,7 @@ class EdiGateway(models.Model):
     # Scheduled jobs
     cron_ids = fields.One2many('ir.cron', 'res_id',
                                domain=[('model_name', '=', 'edi.gateway'),
-                                       ('code', '=', 'model.action_transfer()')],
+                                       ('code', 'like', '%action_transfer%')],
                                string='Schedule')
     cron_count = fields.Integer(string='Schedule Count',
                                 compute='_compute_cron_count')
@@ -270,11 +270,11 @@ class EdiGateway(models.Model):
         self.ensure_one()
         action = self.env.ref('edi.cron_action').read()[0]
         action['domain'] = [('model_name', '=', 'edi.gateway'),
-                            ('code', '=', 'model.action_transfer()'),
+                            ('code', 'like', '%action_transfer%'),
                             ('res_id', '=', self.id)]
-        action['context'] = {'default_model': 'edi.gateway',
-                             # TODO check default_action
-                             'default_function': 'action_transfer',
+        action['context'] = {'default_model_id': self.model_id.id,
+                             'default_state': 'code',
+                             'default_code': 'model.action_transfer()',
                              'default_res_id': self.id,
                              'create': True}
         return action

--- a/models/edi_issues.py
+++ b/models/edi_issues.py
@@ -7,8 +7,7 @@ import logging
 _logger = logging.getLogger(__name__)
 
 EDI_FIELD_MAP = [(field, ('edi_%s' % field))
-                 for field in 'doc_id', 'gateway_id', 'transfer_id']
-
+                 for field in ['doc_id', 'gateway_id', 'transfer_id']]
 
 class Project(models.Model):
 
@@ -19,7 +18,7 @@ class Project(models.Model):
 
 class ProjectIssue(models.Model):
 
-    _inherit = 'project.issue'
+    _inherit = 'project.task'
 
     use_edi_fields = fields.Boolean(related='project_id.use_edi_fields')
     edi_doc_id = fields.Many2one('edi.document', string='EDI Document',
@@ -39,14 +38,15 @@ class EdiIssue(models.AbstractModel):
 
     _name = 'edi.issues'
     _description = 'EDI Issue-Tracked Object'
-    _inherit = ['mail.thread', 'ir.needaction_mixin']
+    # TODO: check 'ir.needaction_mixin'
+    _inherit = ['mail.thread']#, 'ir.needaction_mixin']
 
     def _default_project_id(self):
         return self.env.ref('edi.project_default')
 
     project_id = fields.Many2one('project.project', string='Issue Tracker',
                                  required=True, default=_default_project_id)
-    issue_ids = fields.One2many('project.issue', string='Issues',
+    issue_ids = fields.One2many('project.task', string='Issues',
                                 domain=['|', ('stage_id.fold', '=', False),
                                              ('stage_id', '=', False)])
     issue_count = fields.Integer(string='Issue Count',
@@ -84,6 +84,11 @@ class EdiIssue(models.AbstractModel):
         vals[self._fields['issue_ids'].inverse_name] = self.id
         for field, edi_field in EDI_FIELD_MAP:
             if hasattr(self, field):
+                if 'deferred_execution' in self.env.context and field == 'gateway_id':
+                    # Hack to skip logging the error on the gateway if an error
+                    # occurs during deferred execution as this causes
+                    # serilisation errors that mask the underlying error.
+                    continue
                 rec = getattr(self, field)
                 if rec:
                     vals[edi_field] = rec.id
@@ -105,12 +110,17 @@ class EdiIssue(models.AbstractModel):
         # Construct issue
         vals = self._issue_vals()
         vals['name'] = ('[%s] %s' % (self.name, title))
-        issue = self.env['project.issue'].create(vals)
+        issue = self.env['project.task'].create(vals)
 
         # Construct list of threads
         threads = [self]
         for field, edi_field in EDI_FIELD_MAP:
             if field in self._fields:
+                if 'deferred_execution' in self.env.context and field == 'gateway_id':
+                    # Hack to skip logging the error on the gateway if an error
+                    # occurs during deferred execution as this causes
+                    # serilisation errors that mask the underlying error.
+                    continue
                 thread = getattr(self, field)
                 if thread:
                     threads += thread
@@ -121,7 +131,7 @@ class EdiIssue(models.AbstractModel):
         if not isinstance(err, UserError):
             issue.message_post(body=trace, content_subtype='plaintext')
             for thread in threads:
-                thread.message_post(body=trace, content_subtype='plaintext')
+                thread.sudo().message_post(body=trace, content_subtype='plaintext')
 
         # Add detail if applicable
         if detail:
@@ -129,7 +139,7 @@ class EdiIssue(models.AbstractModel):
 
         # Add summary
         for thread in threads:
-            thread.message_post(body=(fmt % title),
+            thread.sudo().message_post(body=(fmt % title),
                                 content_subtype='plaintext')
         return issue
 
@@ -145,7 +155,7 @@ class EdiIssue(models.AbstractModel):
     def action_view_issues(self):
         """View open issues"""
         self.ensure_one()
-        action = self.env.ref('project_issue.action_view_issues').read()[0]
+        action = self.env.ref('project.action_view_task').read()[0]
         action['domain'] = [(self._fields['issue_ids'].inverse_name,
                              '=', self.id)]
         action['context'] = {'default_%s' % k: v

--- a/models/edi_issues.py
+++ b/models/edi_issues.py
@@ -38,7 +38,8 @@ class EdiIssue(models.AbstractModel):
 
     _name = 'edi.issues'
     _description = 'EDI Issue-Tracked Object'
-    # TODO: check 'ir.needaction_mixin'
+    # TODO: 'ir.needaction_mixin' has been removed from odoo10 to odoo11
+    #       nothing similar has been implemented yet
     _inherit = ['mail.thread']#, 'ir.needaction_mixin']
 
     def _default_project_id(self):
@@ -74,6 +75,8 @@ class EdiIssue(models.AbstractModel):
     @api.model
     def _needaction_domain_get(self):
         """Compute domain to filter records requiring an action"""
+        # TODO: 'ir.needaction_mixin' has been removed from odoo10 to odoo11
+        #       nothing similar has been implemented yet
         return [('issue_count', '!=', 0)]
 
     @api.multi

--- a/models/edi_issues.py
+++ b/models/edi_issues.py
@@ -104,7 +104,7 @@ class EdiIssue(models.AbstractModel):
 
         # Parse exception
         args = list(err.args)
-        title = str(args[0] or err)
+        title = str(err)
         detail = '\n'.join([str(x) for x in args if x])
 
         # Construct issue

--- a/models/edi_issues.py
+++ b/models/edi_issues.py
@@ -39,7 +39,8 @@ class EdiIssue(models.AbstractModel):
     _name = 'edi.issues'
     _description = 'EDI Issue-Tracked Object'
     # TODO: 'ir.needaction_mixin' has been removed from odoo10 to odoo11
-    #       nothing similar has been implemented yet
+    #       nothing similar has been implemented yet.
+    #       US1019 to deal with it.
     _inherit = ['mail.thread']#, 'ir.needaction_mixin']
 
     def _default_project_id(self):

--- a/views/edi_document_type_views.xml
+++ b/views/edi_document_type_views.xml
@@ -20,6 +20,7 @@
 		<field name="model_id"/>
 		<field name="rec_type_ids" widget="many2many_tags"/>
 		<field name="sequence_id"/>
+		<field name="defer_execute"/>
 	      </group>
 	      <group name="issues" string="Issues">
 		<field name="project_id"/>
@@ -39,6 +40,7 @@
 	  <field name="sequence" widget="handle"/>
 	  <field name="name"/>
 	  <field name="model_id"/>
+	  <field name="defer_execute"/>
 	  <field name="rec_type_ids" widget="many2many_tags"/>
 	</tree>
       </field>

--- a/views/ir_cron_views.xml
+++ b/views/ir_cron_views.xml
@@ -9,7 +9,7 @@
       <field name="res_model">ir.cron</field>
       <field name="view_type">form</field>
       <field name="view_mode">tree,form</field>
-      <field name="domain">[('model', '=', 'edi.gateway')]</field>
+      <field name="domain">[('model_name', '=', 'edi.gateway')]</field>
       <field name="context">{'create': False}</field>
     </record>
 

--- a/views/project_issue_views.xml
+++ b/views/project_issue_views.xml
@@ -5,8 +5,8 @@
     <!-- EDI project issue form -->
     <record id="project_issue_form" model="ir.ui.view">
       <field name="name">edi.project.issue.form</field>
-      <field name="model">project.issue</field>
-      <field name="inherit_id" ref="project_issue.project_issue_form_view"/>
+      <field name="model">project.task</field>
+      <field name="inherit_id" ref="project.view_task_form2"/>
       <field name="arch" type="xml">
 	<xpath expr="//field[@name='project_id']" position="after">
 	  <field name="use_edi_fields" invisible="1"/>


### PR DESCRIPTION
Do not store the password in the database, load it from the config file
instead.
- Renaming fields to remove "x_".
- Using odoo-core-provided config functions.
- Adding [edi] section into the config file that stores the passwords.

Optional deferred execution of documents.
- Renaming fields to remove "x_".
- Incorporating the deferred logic directly into the do_transfer function,
instead of changing the behaviour of document preparation.
- If an error occurs in deferred execution of a document (e.g. trying to
reserve a split package) and during the deferred execution the gateway
has been changed (e.g. transferred another file), a serilisation error
occurs when the error from deferred execution is recorded, hiding the
initial error. To avoid this when errors occur during deferred execution
they are not logged on the gateway, so serialisation errors do not occur.

Adding field to edi.gateway to record if gateway is for production use.
- Gateways only transfer if the value of their is_production_gateway
field matches that of the 'production' flag in the [edi] section of the
config file.